### PR TITLE
remove docs/readme.rst since it seems to be useless.

### DIFF
--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,1 +1,0 @@
-.. include:: ../README.rst


### PR DESCRIPTION
The situation is that:
/README.rst -> /docs/README.rst
/docs/readme.rst contains one line to include /README.rst

It seems that /docs/readme.rst is not used in any place (verified by grep "readme" * -R) so I think the best way is to remove it.

Also make docs works fine after removing it.

This should solve #12 and #21 