### PR TITLE
Fix rare unicode encode error on entity extraction

### DIFF
--- a/polyglot/mapping/expansion.py
+++ b/polyglot/mapping/expansion.py
@@ -49,7 +49,7 @@ class VocabExpander(OrderedVocabulary):
   def approximate_ids(self, key):
     ids = [id_ for w, id_ in self.approximate(key).items()]
     if not ids:
-      raise KeyError("{} not found".format(key))
+      raise KeyError(u"{} not found".format(key))
     else:
       if self.strategy == 'most_frequent':
         return min(ids)


### PR DESCRIPTION
Example to trigger bug:
```python
# -*- coding: utf-8 -*-
from polyglot.text import Text
text = u'Beginn der Aktion zum 100jährigen Bestehen dieser Einrichtung ist am Sonnabend, 6. Mai, um 11 Uhr auf dem Hanseatenhof in der Innenstadt.'
t = Text(text)
t.entities
```