### PR TITLE
Fix transliteration when the source language is not "en".

### DIFF
--- a/polyglot/transliteration/base.py
+++ b/polyglot/transliteration/base.py
@@ -60,7 +60,7 @@ class Transliterator(object):
     Enlgish word to the target language.
     """
     encoded_word = self.encoder(word)
-    decoded_word = self.decoder(word)
+    decoded_word = self.decoder(encoded_word)
     return decoded_word
 
   @staticmethod


### PR DESCRIPTION
The transliterate function only worked when the source language was set to "en".

The problem was that the transliterate function would turn the source_lang text
into english, and then turn that english part into whatever the destination
language is...

Except that when turning the text from the converted-english part
into the destination language, it never took the converted-english part,
but rather the non-decoded text.

Please consider releasing a new version.
A workaround for people affected by this issue is to call encoder and decoder manually.