### PR TITLE
Add link to GitHub in README

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -18,6 +18,7 @@ multilingual applications.
 
 -  Free software: GPLv3 license
 -  Documentation: http://polyglot.readthedocs.org.
+-  GitHub: https://github.com/aboSamoor/polyglot
 
 Features
 ~~~~~~~~


### PR DESCRIPTION
I found it hard to find my way from the PyPi page and the documentation to the GitHub repo. My simple suggestions is to add it to the top of the README so people can find their way here.