### PR TITLE
Make handling of data path more coherent

### DIFF
--- a/polyglot/__init__.py
+++ b/polyglot/__init__.py
@@ -4,6 +4,8 @@ __author__ = 'Rami Al-Rfou'
 __email__ = 'rmyeid@gmail.com'
 __version__ = '15.10.03'
 
+import os
+import sys
 import types
 
 from six.moves import copyreg
@@ -12,6 +14,13 @@ from .utils import _pickle_method, _unpickle_method
 
 __all__ = ['Sequence', 'TokenSequence']
 
-data_path = '~/'
+# On Windows, use %APPDATA%
+if sys.platform == 'win32' and 'APPDATA' in os.environ:
+  data_path = os.environ['APPDATA']
+else:
+  data_path = '~/'
+data_path = os.environ.get('POLYGLOT_DATA_PATH', data_path)
+data_path = os.path.abspath(os.path.expanduser(data_path))
+polyglot_path = os.path.join(data_path, "polyglot_data")
 
 copyreg.pickle(types.MethodType, _pickle_method, _unpickle_method)

--- a/polyglot/downloader.py
+++ b/polyglot/downloader.py
@@ -87,7 +87,7 @@ from os import path
 from json import loads
 
 
-from polyglot import data_path
+from polyglot import polyglot_path
 from polyglot.detect.langids import isoLangs
 from polyglot.utils import pretty_list
 from icu import Locale
@@ -1030,33 +1030,9 @@ class Downloader(object):
     or on a case-by-case basis using the ``download_dir`` argument when
     calling ``download()``.
 
-    On Windows, the default download directory is
-    ``PYTHONHOME/lib/nltk``, where *PYTHONHOME* is the
-    directory containing Python, e.g. ``C:\\Python25``.
-
-    On all other platforms, the default directory is the first of
-    the following which exists or which can be created with write
-    permission: ``/usr/share/polyglot_data``, ``/usr/local/share/polyglot_data``,
-    ``/usr/lib/polyglot_data``, ``/usr/local/lib/polyglot_data``, ``~/polyglot_data``.
+    On all other platforms, the default directory is ``~/polyglot_data``.
     """
-    # Check if we have sufficient permissions to install in a
-    # variety of system-wide locations.
-    for dir_ in data_path:
-      if (os.path.exists(dir_) and is_writable(dir_)):
-        return dir_
-
-    # On Windows, use %APPDATA%
-    if sys.platform == 'win32' and 'APPDATA' in os.environ:
-      homedir = os.environ['APPDATA']
-
-    # Otherwise, install in the user's home directory.
-    else:
-      homedir = os.path.expanduser('~/')
-      if homedir == '~/':
-        raise ValueError("Could not find a default download directory")
-
-    # append "polyglot_data" to the home directory
-    return os.path.join(homedir, 'polyglot_data')
+    return polyglot_path
 
   def _get_download_dir(self):
     """

--- a/polyglot/load.py
+++ b/polyglot/load.py
@@ -11,17 +11,12 @@ import morfessor
 from six import PY2
 from six.moves import cPickle as pickle
 
-from . import data_path
+from . import polyglot_path
 from .decorators import memoize
 from .downloader import downloader
 from .mapping import Embedding, CountedVocabulary, CaseExpander, DigitExpander
 
 from .utils import _open
-
-if "~" in data_path:
-  data_path = path.expanduser(data_path)
-
-polyglot_path = path.join(path.abspath(data_path), "polyglot_data")
 
 
 resource_dir = {


### PR DESCRIPTION
This is an attempt to fix #54 by making the handling of the Polyglot data path happen in one location instead of twice. It also adds support for an environment variable, ``POLYGLOT_DATA_PATH`` to set the data path to any location the user desires. 