### PR TITLE
Fix issue #60

### DIFF
--- a/polyglot/load.py
+++ b/polyglot/load.py
@@ -48,13 +48,14 @@ def locate_resource(name, lang, filter=None):
 
 
 @memoize
-def load_embeddings(lang="en", task="embeddings", type="cw"):
+def load_embeddings(lang="en", task="embeddings", type="cw", normalize=False):
   """Return a word embeddings object for `lang` and of type `type`
 
   Args:
     lang (string): language code.
     task (string): parameters that define task.
     type (string): skipgram, cw, cbow ...
+    noramlized (boolean): returns noramlized word embeddings vectors.
   """
   src_dir = "_".join((type, task)) if type else task
   p = locate_resource(src_dir, lang)
@@ -66,6 +67,8 @@ def load_embeddings(lang="en", task="embeddings", type="cw"):
     e.apply_expansion(CaseExpander)
   if type == "ue":
     e.apply_expansion(CaseExpander)
+  if normalize:
+    e.normalize_words(inplace=True)
   return e
 
 

--- a/polyglot/tag/base.py
+++ b/polyglot/tag/base.py
@@ -106,10 +106,10 @@ class NEChunker(TaggerBase):
 
   def _load_network(self):
     """ Building the predictor out of the model."""
-    self.embeddings = load_embeddings(self.lang, type='cw')
-    self.embeddings.normalize_words(inplace=True)
+    self.embeddings = load_embeddings(self.lang, type='cw', normalize=True)
     self.model = load_ner_model(lang=self.lang, version=2)
     first_layer, second_layer = self.model
+
     def predict_proba(input_):
       hidden = np.tanh(np.dot(first_layer, input_))
       hidden = np.hstack((hidden, np.ones((hidden.shape[0], 1))))
@@ -135,7 +135,6 @@ class POSTagger(TaggerBase):
   def _load_network(self):
     """ Building the predictor out of the model."""
     self.embeddings = load_embeddings(self.lang, type='cw')
-    #self.embeddings.normalize_words(inplace=True)
     self.model = load_pos_model(lang=self.lang, version=2)
 
     def predict_proba(input_):


### PR DESCRIPTION
Normalizing embedding inplace for NER corrupts the  POS features. Solution is to introduce a new parameter to the load_embedding function that returns different copies for normalized embeddings and unnormalized ones.