### PR TITLE
Fix import of defaultdict

### DIFF
--- a/polyglot/text.py
+++ b/polyglot/text.py
@@ -3,6 +3,8 @@
 
 import sys
 
+from collections import defaultdict
+
 import numpy as np
 
 from polyglot.base import Sequence, TextFile, TextFiles


### PR DESCRIPTION
Line 173, function word_counts() uses it, but it’s not imported.