### PR TITLE
Fix requirements installation in Python 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ wheel>=0.23.0
 PyICU>=1.8
 pycld2>=0.3
 six>=1.7.3
-futures>=2.1.6
+futures>=3.0.5
 morfessor>=2.0.2a1
 numpy>=1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ wheel>=0.23.0
 PyICU>=1.8
 pycld2>=0.3
 six>=1.7.3
-futures>=3.0.5
+futures>=2.1.6
 morfessor>=2.0.2a1
 numpy>=1.6.1

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open('HISTORY.rst') as history_file:
 
 packages = set(open("requirements.txt", "r").read().splitlines())
 
-requirements = filter(lambda x: "http" not in x, packages)
+requirements = list(filter(lambda x: "http" not in x, packages))
 
 test_requirements = [
     # TODO: put package test requirements here


### PR DESCRIPTION
When using the package in Python 3.x, I noticed dependencies don't get correctly installed.
I ended up pinpointing the issue to the usage of filter() in setup.py, which in Python 3.x returns a filter object which setuptools doesn't seem to like..
This fixes it by casting explicitly to list.