### PR TITLE
Fix error: UnicodeDecodeError: 'charmap' codec can't decode byte 0x81…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ except ImportError:
     from distutils.core import setup
 
 
-with open('README.rst') as readme_file:
+with open('README.rst', encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with open('HISTORY.rst', encoding="utf-8") as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 packages = set(open("requirements.txt", "r").read().splitlines())


### PR DESCRIPTION
… ...

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "...\polyglot\setup.py", line 15, in <module>
        readme = readme_file.read()
      File "h:\program files (x86)\python35-32\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 4941: character maps to <undefined>