### PR TITLE
Remove readme read

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 with open('README.rst') as readme_file:
-    readme = readme_file.read()
+    # readme = readme_file.read()
 
 with open('HISTORY.rst') as history_file:
     history = history_file.read().replace('.. :changelog:', '')


### PR DESCRIPTION
I got problems when I run `pip install polyglot` even when my python encoding setting are in UTF8.

```
File \"<string>\", line 1, in <module>
File \"/tmp/pip-build-t7iemtr5/polyglot/setup.py\", line 15, in <module> 
    readme = readme_file.read()
File \"/usr/lib/python3.4/encodings/ascii.py\", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2330: ordinal not in range(128)
```