### PR TITLE
FIX: BaseBlob.words(self) incorrect docstring

### DIFF
--- a/polyglot/text.py
+++ b/polyglot/text.py
@@ -67,8 +67,7 @@ class BaseBlob(StringlikeMixin, BlobComparableMixin):
 
   @property
   def words(self):
-    """Return a list of word tokens. This excludes punctuation characters.
-    If you want to include punctuation characters, access the ``tokens``
+    """Return a list of word tokens. This is an alias for the ``tokens``
     property.
     :returns: A :class:`WordList <WordList>` of word tokens.
     """


### PR DESCRIPTION
The docstring for `BaseBlob.words(self)` was incorrectly claiming to return a list of tokens **without** punctuation characters and advised users to use `BaseBlob.tokens(self)` if punctuation was required. In reality, `BaseBlob.words(self)` is simply an alias for `BaseBlob.tokens(self)`.

In the name of backwards compability (considering that there are no bug reports of this in the GitHub Issues) this commit simply corrects the documentation rather than changing the implementation.