### PR TITLE
Resolved some Windows specific issues

### DIFF
--- a/polyglot/__main__.py
+++ b/polyglot/__main__.py
@@ -6,7 +6,10 @@ import sys
 from io import open
 from argparse import ArgumentParser, FileType
 from collections import Counter
-from signal import signal, SIGPIPE, SIG_DFL
+if sys.platform == 'win32':
+  from signal import signal, SIGABRT, SIG_DFL
+else:
+  from signal import signal, SIGPIPE, SIG_DFL
 import logging
 
 import six
@@ -25,7 +28,10 @@ from polyglot.tokenize import SentenceTokenizer, WordTokenizer
 from polyglot.transliteration import Transliterator
 from polyglot.utils import _print
 
-signal(SIGPIPE, SIG_DFL)
+if sys.platform == 'win32':
+  signal(SIGABRT, SIG_DFL)
+else:
+  signal(SIGPIPE, SIG_DFL)
 logger = logging.getLogger(__name__)
 LOGFORMAT = "%(asctime).19s %(levelname)s %(filename)s: %(lineno)s %(message)s"
 

--- a/polyglot/downloader.py
+++ b/polyglot/downloader.py
@@ -205,15 +205,15 @@ class Package(object):
   def fromcsobj(csobj):
     attrs = csobj
     id_ = attrs["id"]
-    id_ = id_.split(path.sep)
+    id_ = id_.split('/')
     id = ".".join(id_[1:3])
-    name = attrs["name"].replace(path.sep, '.')
+    name = attrs["name"].replace('/', '.')
     subdir = path.dirname(attrs["name"])
     url = attrs["mediaLink"]
     size = attrs["size"]
     filename = attrs["name"]
-    task = subdir.split(path.sep)[0]
-    language = subdir.split(path.sep)[1]
+    task = subdir.split('/')[0]
+    language = subdir.split('/')[1]
     attrs = attrs
     return Package(**locals())
 


### PR DESCRIPTION
Hello,

I made some fixes that resolve issues for Windows users.

On Windows, `os.path.sep` is `'\\'` instead of `'/'` that caused `Index out of range` errors while using polyglot downloader. So I changed `os.path.sep` to a hard-coded string here as it does not change between any OS.

Windows also does not have `SIGPIPE`. So I changed it to `SIGABR` that seems functionally the closest one to `SIGPIPE`.

I have tested my fixes on two 64-bit Windows 10 machines with Python 3.6 installed and was finally able to download morph2 files as well as use other options of downloader. No Python version-specific changes were implemented. For non-Windows machines, the code stays the same.

Best regards,
Janis