### PR TITLE
Fix tiny typo on docs, Segementation --> Segmentation

### DIFF
--- a/docs/Tokenization.rst
+++ b/docs/Tokenization.rst
@@ -63,7 +63,7 @@ detect the language used first before calling the tokenizer
     name:             code: zh       confidence:  99.0 read bytes:  1920
 
 
-Sentence Segementation
+Sentence Segmentation
 ----------------------
 
 If we are interested in segmenting the text first into sentences, we can

--- a/notebooks/Tokenization.ipynb
+++ b/notebooks/Tokenization.ipynb
@@ -131,7 +131,7 @@
     "collapsed": true
    },
    "source": [
-    "## Sentence Segementation"
+    "## Sentence Segmentation"
    ]
   },
   {


### PR DESCRIPTION
Fixed a minor typo in the Tokenization section of the docs. 
"Segementation" --> Segmentation