### PR TITLE
replace pycld2 with cld2-cffi

### DIFF
--- a/polyglot/detect/base.py
+++ b/polyglot/detect/base.py
@@ -9,7 +9,7 @@ import logging
 
 
 from icu import Locale
-import pycld2 as cld2
+import cld2
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ class Detector(object):
     if not reliable:
       self.reliable = False
       reliable, index, top_3_choices = cld2.detect(t, bestEffort=True)
-      
+
       if not self.quiet:
         if not reliable:
           raise UnknownLanguage("Try passing a longer snippet of text")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 wheel>=0.23.0
 PyICU>=1.8
-pycld2>=0.3
 six>=1.7.3
 futures>=2.1.6
 morfessor>=2.0.2a1
 numpy>=1.6.1
+cld2-cffi>=0.1.4

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,8 +1,8 @@
 wheel>=0.23.0
-pycld2>=0.20
 six>=1.7.3
 futures>=2.1.6
 sphinxcontrib-napoleon>=0.2.8
 mock>=1.0.1
 sphinx-bootstrap-theme>=0.4.5
 alabaster>=0.7.1
+cld2-cffi>=0.1.4


### PR DESCRIPTION
I would really like to add Polyglot as a package on conda-forge.

cld2-cffi is already available on conda-forge, but I was unsuccessful in adding a recipe for pycld2.
Therefore, I would like to replace the dependency for pycld2 and replace it with cld2-cffi.