### PR TITLE
Fix deprecation warning regarding invalid escape sequences.

### DIFF
--- a/polyglot/text.py
+++ b/polyglot/text.py
@@ -215,7 +215,7 @@ class BaseBlob(StringlikeMixin, BlobComparableMixin):
     :rtype: :class:`BaseBlob <BaseBlob>`
     """
     # regex matches: contraction or word or punctuation or whitespace
-    tokens = nltk.tokenize.regexp_tokenize(self.raw, "\w*('\w*)+|\w+|[^\w\s]|\s")
+    tokens = nltk.tokenize.regexp_tokenize(self.raw, r"\w*('\w*)+|\w+|[^\w\s]|\s")
     corrected = (Word(w).correct() for w in tokens)
     ret = ''.join(corrected)
     return self.__class__(ret)


### PR DESCRIPTION
Fixes below warning by using https://github.com/asottile/pyupgrade/

```
 find . -iname '*.py' | grep -vE 'example|docs' | xargs -P 4 -I{} python3.8 -Wall -m py_compile {}
./polyglot/text.py:218: DeprecationWarning: invalid escape sequence \w
  tokens = nltk.tokenize.regexp_tokenize(self.raw, "\w*('\w*)+|\w+|[^\w\s]|\s")
```