### PR TITLE
Fix locale setting in tokenization

### DIFF
--- a/polyglot/tokenize/base.py
+++ b/polyglot/tokenize/base.py
@@ -11,7 +11,7 @@ class Breaker(object):
   """ Base class to segment text."""
 
   def __init__(self, locale):
-    self.locale = Locale('locale')
+    self.locale = Locale(locale)
     self.breaker = None
 
   def transform(self, sequence):
@@ -23,7 +23,7 @@ class Breaker(object):
       seq.idx.extend([offset+x for x in self.breaker])
     return seq
 
- 
+
 class SentenceTokenizer(Breaker):
   """ Segment text to sentences. """
 


### PR DESCRIPTION
Hello! I think I caught a bug here. The variable `locale` should be passed to the constructor of `Locale` and not the literal word `'locale'`